### PR TITLE
fix: production docker stack — env vars + missing shared/dist

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,10 +51,11 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-miu2d_db}
       NODE_ENV: production
       PORT: 4000
-      MINIO_ENDPOINT: minio
-      MINIO_PORT: 9100
-      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-minio}
-      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minio123}
+      S3_ENDPOINT: http://minio:9000
+      S3_PUBLIC_ENDPOINT: ${S3_PUBLIC_ENDPOINT:-http://localhost:9100}
+      S3_REGION: us-east-1
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minio}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minio123}
       MINIO_BUCKET: ${MINIO_BUCKET:-miu2d}
     ports:
       - "4100:4000"

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -64,6 +64,9 @@ COPY packages/server/package.json ./packages/server/
 # 从构建阶段复制构建产物
 COPY --from=builder /app/packages/server/dist ./packages/server/dist
 
+# 复制 shared/locales 编译产物（runtime 动态加载）
+COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
+
 # 复制 prisma schema 和迁移文件
 COPY --from=builder /app/packages/server/prisma ./packages/server/prisma
 


### PR DESCRIPTION
## Summary

Two issues that only surface on a clean `docker compose --profile production build`. The `pnpm dev` path is unaffected because it uses workspace symlinks directly; production docker hits both because the runner stage is isolated and rebuilt from scratch.

## 1. Wrong env var names in `docker-compose.yml`

The server only reads `S3_ENDPOINT` (default `http://localhost:9100`) — see `packages/server/src/env.ts`. The compose file was passing `MINIO_ENDPOINT` / `MINIO_PORT`, which the server ignores. Result: server tries `localhost:9100` from inside the container, every S3 call fails with `ECONNREFUSED ::1:9100`, and `/api/data` etc. return 500.

Switched to canonical names:
- `S3_ENDPOINT=http://minio:9000` for in-network server ↔ MinIO traffic
- `S3_PUBLIC_ENDPOINT` overridable so presigned URLs sign against the host browsers actually reach
- `S3_REGION=us-east-1`
- `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` (matches what the env reader expects)

## 2. Missing `packages/shared/dist` in runner stage

The builder runs `pnpm build:locales` for `@miu2d/shared`, but the runner only copies `packages/server/dist` and `packages/server/prisma`. `@miu2d/shared`'s `package.json` is in the runner (so `pnpm install --prod` keeps the workspace symlink) but its `dist/` is not, and locales are loaded via dynamic `import("@miu2d/shared/locales/...")` which rolldown can't inline. The container starts, then crashes:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'/app/packages/server/node_modules/@miu2d/shared/dist/locales/index.js'
imported from /app/packages/server/dist/main.js
```

Added one line to the runner stage:

```dockerfile
COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
```

## Test plan

- [x] `docker compose --profile production up -d --build` from scratch (no cache) — server starts cleanly, all routers register, no `ECONNREFUSED`
- [x] `GET /game/<slug>/api/config` returns 200 with valid JSON
- [x] `GET /game/<slug>/resources/<path>` returns 200 (S3 path now resolves)
- [x] Presigned URLs (logos etc.) sign against `S3_PUBLIC_ENDPOINT` and load in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)